### PR TITLE
Check if the service is destroyed before setting marks

### DIFF
--- a/addon/services/ember-overlays.js
+++ b/addon/services/ember-overlays.js
@@ -23,6 +23,8 @@ export default Ember.Service.extend({
   },
 
   _update() {
+    if (this.isDestroyed) { return; }
+
     let sources = this._markSources;
     let marks = Object.create(null);
     for (let sourceId in sources) {


### PR DESCRIPTION
This prevents the ember-overlays service from setting properties when it's being destroyed when an application is being tested.

We're currently seeing this break our tests.