### PR TITLE
Add guard for mark-infos removed from DOM

### DIFF
--- a/addon/mark-info.js
+++ b/addon/mark-info.js
@@ -8,6 +8,7 @@ export default class MarkInfo {
   }
 
   bounds() {
+    if (!this._firstNode.parentNode || !this._lastNode.parentNode) { return; }
     let r = new Range();
     r.setStartBefore(this._firstNode);
     r.setEndAfter(this._lastNode);


### PR DESCRIPTION
This addresses what I believe to be an additional symptom of the problem addressed by the recent PR by @tim-evans.