### PR TITLE
use more fastboot friendly liquid fire

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-concurrency": "^0.7.19",
-    "liquid-fire": "^0.28.0"
+    "liquid-fire": "^0.29.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
@ef4 can you merge this PR and rev? this add-on doesn't use the fastboot friendly version of liquid fire that we worked on, and is preventing our app from playing nice in fastboot. 