### PR TITLE
More robust fix for fixing `focused` behavior

### DIFF
--- a/addon/scrim-fader.js
+++ b/addon/scrim-fader.js
@@ -15,7 +15,7 @@ export default function scrimFader() {
     promises = promises.concat(Array.from(this.newElement.find('> .overlay-scrim')).map(
       elt => animate($(elt), { opacity: [maxOpacity, 0]}, { queue: false, duration: 250 } )
     ));
+    this.newElement[0].style.visibility = '';
   }
-  this.newElement.style.visibility = '';
   return RSVP.all(promises);
 }


### PR DESCRIPTION
In some cases, `this.newElement` was undefined which caused an error. Also, `this.newElement` was a jQuery "thing" (a collection with 1 element) which didn't have a style.