### PR TITLE
Reveal the overlay on hover only if hoverable is true

### DIFF
--- a/addon/components/create-overlay.js
+++ b/addon/components/create-overlay.js
@@ -1,4 +1,4 @@
-import { or } from '@ember/object/computed';
+import { or, and } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from '../templates/components/create-overlay';
 import raf from '../raf';
@@ -84,7 +84,8 @@ export default Component.extend({
     }
   }).on('didInsertElement'),
 
-  reveal: or('hovered', 'highlighted', 'focused'),
+  reveal: or('hoveredAndHoverable', 'highlighted', 'focused'),
+  hoveredAndHoverable: and('hovered', 'hoverable'),
 
   actions: {
     beginHover() {


### PR DESCRIPTION
If `hoverable` is set to false while a component is `hovered` the overlay will continue to display. This changes it so `reveal` will be `false` if a component is `hovered` but not `hoverable`