### PR TITLE
bugfix: make custom label components interactable

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -30,7 +30,6 @@
     transform-origin: bottom left;
     background-color: #63A9FA;
     color: white;
-    pointer-events: none;
 }
 
 .overlay-border {


### PR DESCRIPTION
* [x] Fixes an issue where passing custom label components to an overlay weren't clickable.