### PR TITLE
Fix label flicker on mouse hover

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -30,6 +30,7 @@
     transform-origin: bottom left;
     background-color: #63A9FA;
     color: white;
+    pointer-events: none;
 }
 
 .overlay-border {


### PR DESCRIPTION
This small fix prevents flickering of overlay labels on mouse hover.

Without the fix:
![Without the fix](https://user-images.githubusercontent.com/61469/77472313-b7fb7280-6de1-11ea-8561-b3133c2f88f1.gif)

With the fix:
![with](https://user-images.githubusercontent.com/61469/77472367-ccd80600-6de1-11ea-8b9e-714641a5474e.gif)

